### PR TITLE
don't store a function in the HMAC state

### DIFF
--- a/DRBG.cabal
+++ b/DRBG.cabal
@@ -22,7 +22,7 @@ flag test
 
 Library
   Build-Depends: base >= 4.0 && < 5, cereal >= 0.2,
-                 bytestring, prettyclass, tagged >= 0.2,
+                 bytestring, prettyclass, tagged >= 0.7,
                  crypto-api >= 0.13, cryptohash-cryptoapi >= 0.1,
                  parallel, mtl >= 2.0, cipher-aes128 >= 0.6, entropy
   ghc-options: -O2


### PR DESCRIPTION
It looks like `HMAC.State` doesn't actually use the function it stores -- just treats it as a way to get at the phantom type variable. This is unfortunate, because it means there's lots of things you can't do with a `State` that would be nice (like serialize it). The patch below fixes this: it removes the `hashAlg` function from the `State`, and calls appropriate type-restricted functions on the state itself to get at the type variable instead.

This doesn't change the public API of the package (since the constructor and fields of `State` are not exported), but it changes just enough that Template Haskell can derive some handy classes. Not sure what you want to do about version number given that.

This also requires a somewhat newer copy of `tagged`, though this could be avoided by reimplementing the trivial `proxy` function if desired.
