### PR TITLE
DRBG.cabal: port to cabal testsuite infrastructure

### DIFF
--- a/DRBG.cabal
+++ b/DRBG.cabal
@@ -10,7 +10,7 @@ synopsis:       Deterministic random bit generator (aka RNG, PRNG) based
 category:       Cryptography
 stability:      stable
 build-type:     Simple
-cabal-version:  >= 1.6
+cabal-version:  >= 1.8
 tested-with:    GHC == 6.10.1
 Data-Files: Test/HMAC_DRBG.txt Test/Hash_DRBG.txt Test/CTR_DRBG.txt Test/Dual_EC_DRBG.txt CHANGELOG
 extra-source-files:
@@ -34,12 +34,11 @@ Library
                    Crypto.Random.DRBG.Types
   other-modules: Crypto.Random.DRBG.HashDF
 
-Executable drbg_test
-  if !flag(test)
-    buildable: False
+Test-Suite test-drbg
+  ghc-options: -Wall
+  Type:                 exitcode-stdio-1.0
   main-is: Test/KAT.hs
-  if flag(test)
-    build-depends:   base
+  build-depends:     base
                    , QuickCheck
                    , crypto-api
                    , bytestring
@@ -50,7 +49,12 @@ Executable drbg_test
                    , HUnit
                    , test-framework
                    , test-framework-hunit
-                   , cipher-aes
+                   , cipher-aes128
+                   , entropy
+                   , mtl
+                   , parallel
+                   , prettyclass
+                   , tagged
   other-modules: Paths_DRBG
 
 source-repository head

--- a/Test/KAT.hs
+++ b/Test/KAT.hs
@@ -66,7 +66,7 @@ categoryToTest_CTR (props, ts)
         ret    <- lookup "ReturnedBits" t'
         let f =
                 let hx        = hexStringToBS
-                    Just st0  = CTR.instantiate (hx eIn) (hx per) :: Maybe (CTR.State AESKey)
+                    Just st0  = CTR.instantiate (hx eIn) (hx per) :: Maybe (CTR.State AESKey128)
                     Just st1  = CTR.reseed st0 (hx eInPR1) (hx aIn1)
                     Just (_,st2) = CTR.generate st1 olen B.empty
                     Just st3 = CTR.reseed st2 (hx eInPR2) (hx aIn2)
@@ -88,7 +88,7 @@ categoryToTest_CTR (props, ts)
         ret   <- lookup "ReturnedBits" t
         let f =
                 let hx = hexStringToBS
-                    Just st0     = CTR.instantiate (hx eIn) (hx per) :: Maybe (CTR.State AESKey)
+                    Just st0     = CTR.instantiate (hx eIn) (hx per) :: Maybe (CTR.State AESKey128)
                     Just (_,st1) = CTR.generate st0 olen (hx aIn1)
                     Just st2     = CTR.reseed st1 (hx eInRS) (hx aInRS)
                     Just (r1, _) = CTR.generate st2 olen (hx aIn2)


### PR DESCRIPTION
Fixed test buildability, but test still fails AES part.

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
